### PR TITLE
Fixed validation of empty date/time input fields

### DIFF
--- a/src/Controls/DateTime/AbstractDateTimeInput.php
+++ b/src/Controls/DateTime/AbstractDateTimeInput.php
@@ -218,6 +218,10 @@ abstract class AbstractDateTimeInput extends BaseControl
 	 */
 	protected function getValueAsDateTimeImmutable()
 	{
+		if ($this->value === null || $this->value === '') {
+			return null;
+		}
+
 		$date = $this->parser->parse($this->value);
 		if ($date === null) {
 			$this->addError($this->invalidValueMessage);


### PR DESCRIPTION
@f3l1x Just quick fix. Validation of format was triggered even for emtpy fields which caused unwanted errors.